### PR TITLE
feat: [CDE-823]: use configurable image gateway and runner

### DIFF
--- a/modules/infra/gateway_instance.tf
+++ b/modules/infra/gateway_instance.tf
@@ -2,10 +2,7 @@ locals {
   # Generate the unique suffix for the template name
   gateway_suffix = "${replace(local.gateway_version, ".", "-")}-${substr(uuid(), 0, 8)}"
 }
-data "google_compute_image" "latest_image" {
-  family  = local.gateway_vm_image_family
-  project = local.gateway_vm_image_project
-}
+
 # Create an instance template
 resource "google_compute_region_instance_template" "default_template" {
   for_each        = local.region_configs
@@ -14,7 +11,7 @@ resource "google_compute_region_instance_template" "default_template" {
   region       = local.region_configs[each.key].region_name
 
   disk {
-    source_image = data.google_compute_image.latest_image.self_link
+    source_image = local.gateway_vm_image_name
     auto_delete  = true
     boot         = true
     disk_size_gb = 50

--- a/modules/infra/locals.tf
+++ b/modules/infra/locals.tf
@@ -14,13 +14,13 @@ locals {
   gateway_vm_tags = local.infra_config.gateway.vm_tags
   gateway_machine_type = local.infra_config.gateway.machine_type
   gateway_instances = local.infra_config.gateway.instances
-  gateway_vm_image_family = local.infra_config.gateway.vm_image.family
-  gateway_vm_image_project = local.infra_config.gateway.vm_image.project
+  gateway_vm_image_name = local.infra_config.gateway.vm_image_name
   gateway_secret = local.infra_config.gateway.shared_secret
   gateway_version = local.infra_config.gateway.version
 
   runner_vm_zone = local.infra_config.runner.zone
   runner_vm_region = local.infra_config.runner.region
+  runner_vm_image_name = local.infra_config.vm_image_name
 
   provisioner_service_account = local.infra_config.project.service_account # Service account used to deploy gateway
   cde_manager_url = local.infra_config.gateway.cde_manager_url

--- a/modules/infra/runner_instance.tf
+++ b/modules/infra/runner_instance.tf
@@ -6,7 +6,7 @@ resource "google_compute_instance" "runner_instance" {
 
   boot_disk {
     initialize_params {
-      image = data.google_compute_image.latest_image.self_link
+      image = local.runner_vm_image_name
       size  = 30
       type  = "pd-standard"
     }


### PR DESCRIPTION
* Directly use full image path for gateway and runner. 
 *  we are returning full image path in infra.yml with `vm_image_name` key
* Configure vm image for runne vm separately 